### PR TITLE
Corrigir _but_check

### DIFF
--- a/leia.py
+++ b/leia.py
@@ -344,7 +344,7 @@ class SentimentIntensityAnalyzer(object):
                     elif si > bi:
                         sentiments.pop(si)
                         sentiments.insert(si, sentiment * 1.5)
-            return sentiments
+        return sentiments
 
 
     @staticmethod


### PR DESCRIPTION
O return estava dentro do for, fazendo com que apenas a palavra 'mas' fosse considerada.